### PR TITLE
Fixes downloading media

### DIFF
--- a/mautrix_twitter/portal.py
+++ b/mautrix_twitter/portal.py
@@ -641,6 +641,8 @@ class Portal(DBPortal, BasePortal):
         self, source: u.User, intent: IntentAPI, message: MessageData
     ) -> MediaMessageEventContent | None:
         media = message.attachment.media
+        # Fix for new media URLs
+        media.media_url_https = media.media_url_https.replace("ton.twitter.com/1.1", "ton.x.com/i")
         reuploaded_info = await self._reupload_twitter_media(source, media.media_url_https, intent)
         thumbnail_info = None
         if media.video_info:


### PR DESCRIPTION
Twitter is now using `https://ton.x.com/i/ton/[...]` for media sent over DM, despite their API still returning urls using `https://ton.twitter.com/1.1/ton/[...]`.

They do the same replace proposed in this PR in their own JS bundle:

<img width="540" alt="image" src="https://github.com/mautrix/twitter/assets/855995/8ef2433a-62ae-41bc-a871-9790f4361f86">

https://abs.twimg.com/responsive-web/client-web/main.87b67eda.js