### PR TITLE
connector/sync: fix NPE when syncing channels

### DIFF
--- a/pkg/connector/client_sync.go
+++ b/pkg/connector/client_sync.go
@@ -44,7 +44,13 @@ func (tc *TwitterClient) syncChannels(ctx context.Context, initialInboxState *re
 			break
 		}
 
+		if inboxData.Conversations == nil {
+			inboxData.Conversations = map[string]types.Conversation{}
+		}
 		maps.Copy(inboxData.Conversations, nextInboxTimelineResponse.InboxTimeline.Conversations)
+		if inboxData.Users == nil {
+			inboxData.Users = map[string]types.User{}
+		}
 		maps.Copy(inboxData.Users, nextInboxTimelineResponse.InboxTimeline.Users)
 		inboxData.Entries = append(inboxData.Entries, nextInboxTimelineResponse.InboxTimeline.Entries...)
 


### PR DESCRIPTION
Before this change syncChannels would NPE if inboxData.Conversations was
nil due to being omitted because it's empty.

This change ensures that the Conversations map is not nil before copying
to it.

Signed-off-by: Sumner Evans <sumner.evans@automattic.com>
