### PR TITLE
connector: fix accepting message request after upstream accept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v26.05
+
+* Fixed accepting message requests on X failing with HTTP 404 (X error code 279) after the conversation had already been accepted on x.com or another client.
+
 # v26.04
 
 * Fixed encryption using non-latest key in some cases.

--- a/pkg/connector/handlematrix.go
+++ b/pkg/connector/handlematrix.go
@@ -923,5 +923,24 @@ func (tc *TwitterClient) HandleMute(ctx context.Context, msg *bridgev2.MatrixMut
 }
 
 func (tc *TwitterClient) HandleMatrixAcceptMessageRequest(ctx context.Context, msg *bridgev2.MatrixAcceptMessageRequest) error {
-	return tc.client.AcceptConversation(ctx, ParsePortalID(msg.Portal.ID))
+	conversationID := ParsePortalID(msg.Portal.ID)
+	err := tc.client.AcceptConversation(ctx, conversationID)
+	if err != nil && !errors.Is(err, (twittermeow.TwitterError{Code: 279})) {
+		return err
+	}
+	// Treat success and "conversation doesn't exist" (X code 279) the same way.
+	// 279 fires when the request has already been moved out of the requests bucket
+	// upstream, typically because the user accepted on x.com or another client.
+	// The portal still needs to be promoted locally so the chat leaves Requests
+	// and the Accept button stops re-firing the same upstream 404.
+	meta := msg.Portal.Metadata.(*PortalMetadata)
+	if !meta.Trusted {
+		meta.Trusted = true
+		if saveErr := msg.Portal.Save(ctx); saveErr != nil {
+			zerolog.Ctx(ctx).Warn().Err(saveErr).
+				Str("conversation_id", conversationID).
+				Msg("Failed to save portal metadata with Trusted=true after accepting message request")
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## What

X's `accept.json` returns HTTP 404 with error code 279 ("The direct
message conversation doesn't exist") when the conversation has already
been moved out of the message-requests bucket upstream, for example
because the user accepted on x.com or another client. The bridge
currently surfaces that as a hard error, so the chat stays in the
Beeper Requests folder and clicking Accept hits the same 404 every time.

## Fix

In `HandleMatrixAcceptMessageRequest`, treat error code 279 the same
as a 2xx response: flip `PortalMetadata.Trusted = true`, save the
portal, and return nil. Also flip Trusted on the normal success path,
which `dbmeta.go` documents as the expected behaviour but the code
was not doing.

## Edge case

Code 279 can also fire if the conversation was deleted upstream
entirely (not just moved out of the requests bucket). In that case
the portal still flips to Trusted, which leaves an empty chat in the
inbox instead of a wedged one in Requests. Same outcome the user
would get today by replying natively to nudge an upstream sync.