### PR TITLE
handletwit: avoid blocking sync on profile updates

### DIFF
--- a/pkg/connector/chatsync.go
+++ b/pkg/connector/chatsync.go
@@ -449,15 +449,8 @@ func (tc *TwitterClient) syncUntrustedChannels(ctx context.Context) {
 		}
 	}
 
-	// Update ghost info for users (ensures profile pictures are visible)
+	// Cache users and update ghost info when needed.
 	tc.updateTwitterUserInfo(ctx, inbox)
-
-	// Cache users from inbox
-	tc.userCacheLock.Lock()
-	for userID, user := range inbox.Users {
-		tc.userCache[userID] = user
-	}
-	tc.userCacheLock.Unlock()
 
 	// Process only untrusted conversations (message requests)
 	untrustedCount := 0

--- a/pkg/connector/handletwit.go
+++ b/pkg/connector/handletwit.go
@@ -819,28 +819,24 @@ func (tc *TwitterClient) updateTwitterUserInfo(ctx context.Context, inbox *respo
 	}
 	log := zerolog.Ctx(ctx)
 
-	type userInfoUpdate struct {
-		userID string
-		user   *types.User
-	}
-	var updates []userInfoUpdate
+	updates := make(map[string]*types.User)
 
 	tc.userCacheLock.Lock()
 	for userID, user := range inbox.Users {
 		cached := tc.userCache[userID]
 		if cached == nil || cached.Name != user.Name || cached.ScreenName != user.ScreenName || cached.ProfileImageURLHTTPS != user.ProfileImageURLHTTPS {
-			updates = append(updates, userInfoUpdate{userID: userID, user: user})
+			updates[userID] = user
 		}
 		tc.userCache[userID] = user
 	}
 	tc.userCacheLock.Unlock()
 
-	for _, update := range updates {
-		ghost, err := tc.connector.br.GetGhostByID(ctx, MakeUserID(update.userID))
+	for userID, update := range updates {
+		ghost, err := tc.connector.br.GetGhostByID(ctx, MakeUserID(userID))
 		if err != nil {
-			log.Debug().Err(err).Str("user_id", update.userID).Msg("Failed to get ghost by ID for user info update")
+			log.Debug().Err(err).Str("user_id", userID).Msg("Failed to get ghost by ID for user info update")
 			continue
 		}
-		ghost.UpdateInfo(ctx, tc.connector.wrapUserInfo(tc.client, update.user))
+		ghost.UpdateInfo(ctx, tc.connector.wrapUserInfo(tc.client, update))
 	}
 }

--- a/pkg/connector/handletwit.go
+++ b/pkg/connector/handletwit.go
@@ -542,11 +542,6 @@ func (tc *TwitterClient) HandlePollingEvent(evt types.TwitterEvent, inbox *respo
 	// Always cache users from inbox when available - needed for portal creation
 	if inbox != nil {
 		tc.updateTwitterUserInfo(context.TODO(), inbox)
-		tc.userCacheLock.Lock()
-		for userID, user := range inbox.Users {
-			tc.userCache[userID] = user
-		}
-		tc.userCacheLock.Unlock()
 	}
 
 	if evt == nil {
@@ -816,25 +811,36 @@ func (tc *TwitterClient) handlePollingMessage(evt *types.Message, inbox *respons
 	}).Success
 }
 
-// updateTwitterUserInfo updates ghost info when user data changes.
-// This ensures profile pictures are visible for users in message request conversations.
+// updateTwitterUserInfo caches inbox users and updates ghost info when user data changes.
+// The cache lock must not be held while doing ghost/avatar I/O.
 func (tc *TwitterClient) updateTwitterUserInfo(ctx context.Context, inbox *response.TwitterInboxData) {
 	if inbox == nil || inbox.Users == nil {
 		return
 	}
 	log := zerolog.Ctx(ctx)
-	tc.userCacheLock.RLock()
-	defer tc.userCacheLock.RUnlock()
 
+	type userInfoUpdate struct {
+		userID string
+		user   *types.User
+	}
+	var updates []userInfoUpdate
+
+	tc.userCacheLock.Lock()
 	for userID, user := range inbox.Users {
 		cached := tc.userCache[userID]
 		if cached == nil || cached.Name != user.Name || cached.ScreenName != user.ScreenName || cached.ProfileImageURLHTTPS != user.ProfileImageURLHTTPS {
-			ghost, err := tc.connector.br.GetGhostByID(ctx, MakeUserID(userID))
-			if err != nil {
-				log.Debug().Err(err).Str("user_id", userID).Msg("Failed to get ghost by ID for user info update")
-				continue
-			}
-			ghost.UpdateInfo(ctx, tc.connector.wrapUserInfo(tc.client, user))
+			updates = append(updates, userInfoUpdate{userID: userID, user: user})
 		}
+		tc.userCache[userID] = user
+	}
+	tc.userCacheLock.Unlock()
+
+	for _, update := range updates {
+		ghost, err := tc.connector.br.GetGhostByID(ctx, MakeUserID(update.userID))
+		if err != nil {
+			log.Debug().Err(err).Str("user_id", update.userID).Msg("Failed to get ghost by ID for user info update")
+			continue
+		}
+		ghost.UpdateInfo(ctx, tc.connector.wrapUserInfo(tc.client, update.user))
 	}
 }


### PR DESCRIPTION
## Summary

Fix a startup sync stall caused by REST inbox profile updates holding `userCacheLock` while doing ghost/profile/avatar I/O.

The REST inbox path now:

- caches inbox users under a short lock
- records which ghost profiles need updating
- releases `userCacheLock`
- performs `GetGhostByID` / `UpdateInfo` after the lock is released

This preserves profile updates for message requests while preventing slow avatar downloads/uploads from blocking XChat from caching users and creating rooms.

## Verification

- `go test ./...`
- `./build.sh`
- `go vet ./...`
- `staticcheck ./...`
- `git diff --check`

Live clean self-hosted verification with `sh-twitter`:

- deleted `sh-twitter` with `bbctl delete sh-twitter`
- wiped local runtime DB/config under `~/.local/share/mautrix-twitter`
- rebuilt and ran `mautrix-twitter v26.04+dev.09c37f66`
- logged in fresh through Beeper Desktop
- observed login completed at `2026-05-30T19:39:04.012-04:00`
- first XChat inbox page at `2026-05-30T19:39:05.394-04:00`
- first Matrix room create at `2026-05-30T19:39:05.583-04:00`
- first XChat channel synced at `2026-05-30T19:39:06.078-04:00`
- final clean DB counts: `30` portals, `193` messages

Note: `pre-commit` is not installed in my local environment, so I ran the available Go checks above manually.
