### PR TITLE
handlematrix,twittermeow: fix encrypted send signature and pending state

### DIFF
--- a/pkg/connector/handlematrix.go
+++ b/pkg/connector/handlematrix.go
@@ -268,9 +268,9 @@ func (tc *TwitterClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.
 		return tc.sendDirectMessageREST(ctx, msg, conversationID, messageID, text, opts, dbMsg, txnID)
 	}
 
-	// Encrypted conversation: correlate remote echo (XChat RequestID) with this Matrix event.
-	// Without this, the remote echo can get bridged back into Matrix as a duplicate message.
-	msg.AddPendingToSave(dbMsg, txnID, nil)
+	// Encrypted conversation: the mutation response includes the real XChat sequence ID,
+	// so ignore the later remote echo instead of leaving the send pending.
+	msg.AddPendingToIgnore(txnID)
 
 	// Use XChat protocol, with REST fallback on key/token not found.
 	resp, err := tc.client.SendEncryptedMessage(ctx, opts)
@@ -282,7 +282,7 @@ func (tc *TwitterClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.
 				Msg("Falling back to REST API for message send (key/token not found)")
 			return tc.sendDirectMessageREST(ctx, msg, conversationID, messageID, text, opts, dbMsg, txnID)
 		}
-		return nil, err
+		return nil, bridgev2.WrapErrorInStatus(err).WithSendNotice(true)
 	}
 	zerolog.Ctx(ctx).Debug().
 		Str("conversation_id", conversationID).
@@ -291,28 +291,45 @@ func (tc *TwitterClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.
 		Msg("XChat send message response")
 
 	if resp != nil && resp.Data.XChatSendCreateMessageEvent.EncodedMessageEvent != "" {
-		decoded, err := twittermeow.DecodeSendMessageEventResponse(resp.Data.XChatSendCreateMessageEvent.EncodedMessageEvent)
+		evt, err := twittermeow.DecodeSendMessageMutationMessageEvent(resp.Data.XChatSendCreateMessageEvent.EncodedMessageEvent)
 		if err != nil {
 			zerolog.Ctx(ctx).Debug().
 				Err(err).
 				Str("conversation_id", conversationID).
 				Str("message_id", messageID).
 				Msg("Failed to decode XChat send message response")
-		} else if decoded != nil && decoded.MessageEvent != nil && *decoded.MessageEvent != "" {
+		} else if evt != nil && evt.Detail != nil && evt.Detail.MessageFailureEvent != nil {
+			msg.RemovePending(txnID)
+			return nil, bridgev2.WrapErrorInStatus(errors.New(xchatSendFailureMessage(evt.Detail.MessageFailureEvent))).
+				WithStatus(event.MessageStatusFail).
+				WithIsCertain(true).
+				WithSendNotice(true)
+		} else if evt != nil && evt.SequenceId != nil && *evt.SequenceId != "" {
 			zerolog.Ctx(ctx).Debug().
 				Str("conversation_id", conversationID).
 				Str("message_id", messageID).
 				Msg("Decoded XChat send message event")
-			if evt, err := twittermeow.DecodeMessageEvent(*decoded.MessageEvent); err == nil && evt != nil && evt.SequenceId != nil && *evt.SequenceId != "" {
-				dbMsg.ID = MakeMessageID(*evt.SequenceId)
-			}
+			dbMsg.ID = MakeMessageID(*evt.SequenceId)
 		}
 	}
 
 	return &bridgev2.MatrixMessageResponse{
-		DB:      dbMsg,
-		Pending: true,
+		DB:            dbMsg,
+		RemovePending: txnID,
 	}, nil
+}
+
+func xchatSendFailureMessage(failure *payload.MessageFailureEvent) string {
+	switch payload.FailureType(ptr.Val(failure.FailureType)) {
+	case payload.FailureTypeInvalidSenderSignature:
+		return "X rejected this message: invalid sender signature"
+	case payload.FailureTypeContentsTooLarge:
+		return "X rejected this message: contents too large"
+	case payload.FailureTypeRecipientHasNotTrustedConversation:
+		return "X rejected this message: recipient has not trusted this conversation"
+	default:
+		return fmt.Sprintf("X rejected this message: failure type %d", ptr.Val(failure.FailureType))
+	}
 }
 
 // sendDirectMessageREST sends a message via the REST API for untrusted conversations

--- a/pkg/connector/handlematrix.go
+++ b/pkg/connector/handlematrix.go
@@ -290,27 +290,35 @@ func (tc *TwitterClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.
 		Any("response", resp).
 		Msg("XChat send message response")
 
-	if resp != nil && resp.Data.XChatSendCreateMessageEvent.EncodedMessageEvent != "" {
-		evt, err := twittermeow.DecodeSendMessageMutationMessageEvent(resp.Data.XChatSendCreateMessageEvent.EncodedMessageEvent)
-		if err != nil {
-			zerolog.Ctx(ctx).Debug().
-				Err(err).
-				Str("conversation_id", conversationID).
-				Str("message_id", messageID).
-				Msg("Failed to decode XChat send message response")
-		} else if evt != nil && evt.Detail != nil && evt.Detail.MessageFailureEvent != nil {
-			msg.RemovePending(txnID)
-			return nil, bridgev2.WrapErrorInStatus(errors.New(xchatSendFailureMessage(evt.Detail.MessageFailureEvent))).
-				WithStatus(event.MessageStatusFail).
-				WithIsCertain(true).
-				WithSendNotice(true)
-		} else if evt != nil && evt.SequenceId != nil && *evt.SequenceId != "" {
-			zerolog.Ctx(ctx).Debug().
-				Str("conversation_id", conversationID).
-				Str("message_id", messageID).
-				Msg("Decoded XChat send message event")
-			dbMsg.ID = MakeMessageID(*evt.SequenceId)
-		}
+	if resp == nil || resp.Data.XChatSendCreateMessageEvent.EncodedMessageEvent == "" {
+		msg.RemovePending(txnID)
+		return nil, bridgev2.WrapErrorInStatus(errors.New("XChat send message response did not include an encoded message event")).WithSendNotice(true).WithErrorAsMessage()
+	}
+	evt, err := twittermeow.DecodeSendMessageMutationMessageEvent(resp.Data.XChatSendCreateMessageEvent.EncodedMessageEvent)
+	if err != nil {
+		zerolog.Ctx(ctx).Debug().
+			Err(err).
+			Str("conversation_id", conversationID).
+			Str("message_id", messageID).
+			Msg("Failed to decode XChat send message response")
+		msg.RemovePending(txnID)
+		return nil, bridgev2.WrapErrorInStatus(fmt.Errorf("failed to decode XChat send message response: %w", err)).WithSendNotice(true).WithErrorAsMessage()
+	} else if evt != nil && evt.Detail != nil && evt.Detail.MessageFailureEvent != nil {
+		msg.RemovePending(txnID)
+		return nil, bridgev2.WrapErrorInStatus(errors.New(xchatSendFailureMessage(evt.Detail.MessageFailureEvent))).
+			WithStatus(event.MessageStatusFail).
+			WithIsCertain(true).
+			WithSendNotice(true).
+			WithErrorAsMessage()
+	} else if evt != nil && evt.SequenceId != nil && *evt.SequenceId != "" {
+		zerolog.Ctx(ctx).Debug().
+			Str("conversation_id", conversationID).
+			Str("message_id", messageID).
+			Msg("Decoded XChat send message event")
+		dbMsg.ID = MakeMessageID(*evt.SequenceId)
+	} else {
+		msg.RemovePending(txnID)
+		return nil, bridgev2.WrapErrorInStatus(errors.New("XChat send message response did not include a message ID")).WithSendNotice(true).WithErrorAsMessage()
 	}
 
 	return &bridgev2.MatrixMessageResponse{

--- a/pkg/twittermeow/crypto/message.go
+++ b/pkg/twittermeow/crypto/message.go
@@ -584,7 +584,7 @@ func (b *MessageBuilder) Build(ctx context.Context) (*payload.MessageEvent, erro
 			return nil, fmt.Errorf("sign message: %w", err)
 		}
 
-		sigVersion := SignatureVersion3
+		sigVersion := SignatureVersion7
 
 		event.MessageEventSignature = &payload.MessageEventSignature{
 			Signature:        &signature,

--- a/pkg/twittermeow/crypto/signature.go
+++ b/pkg/twittermeow/crypto/signature.go
@@ -14,8 +14,10 @@ import (
 )
 
 const (
-	// SignatureVersion3 is the current signature version for MessageCreateEvent.
+	// SignatureVersion3 is the legacy signature version for MessageCreateEvent verification.
 	SignatureVersion3 = "3"
+	// SignatureVersion7 is the current send signature version for MessageCreateEvent.
+	SignatureVersion7 = "7"
 	// SignatureVersion4 is the current signature version for MarkConversationReadEvent.
 	SignatureVersion4 = "4"
 

--- a/pkg/twittermeow/xchat_processor.go
+++ b/pkg/twittermeow/xchat_processor.go
@@ -583,6 +583,27 @@ func DecodeSendMessageEventResponse(encoded string) (*payload.SendMessageEventRe
 	return &resp, nil
 }
 
+// DecodeSendMessageMutationMessageEvent decodes SendMessageMutation responses.
+// The endpoint has returned both direct MessageEvent payloads and wrapper payloads.
+func DecodeSendMessageMutationMessageEvent(encoded string) (*payload.MessageEvent, error) {
+	evt, err := DecodeMessageEvent(encoded)
+	if err == nil && evt != nil && evt.Detail != nil {
+		return evt, nil
+	}
+
+	resp, wrapperErr := DecodeSendMessageEventResponse(encoded)
+	if wrapperErr != nil {
+		if err != nil {
+			return nil, err
+		}
+		return nil, wrapperErr
+	}
+	if resp == nil || resp.MessageEvent == nil || *resp.MessageEvent == "" {
+		return nil, fmt.Errorf("send message response did not contain a message event")
+	}
+	return DecodeMessageEvent(*resp.MessageEvent)
+}
+
 type decodedInboxMessageEvent struct {
 	seq int64
 	evt *payload.MessageEvent


### PR DESCRIPTION
## Summary
- use signature version 7 for outgoing XChat message-create signatures
- save successful encrypted sends immediately using the returned XChat sequence ID and remove the pending echo ignore entry
- surface XChat send failure events as send failures instead of leaving messages pending

## Verification
- ./build.sh
- git diff --check
- installed the built binary into /Users/r0drz/.local/share/mautrix-twitter/mautrix-twitter and restarted com.beeper.mautrix-twitter-debug
- live send logs showed SendMessageMutation success, decoded XChat send message events, duplicate remote echoes ignored, and Beeper send status SUCCESS

Tests intentionally not run since I was able to reproduce all of this.