### PR TITLE
connector/chatsync: fix XChat chat info sync self-deadlock in portal event handler

### DIFF
--- a/pkg/connector/chatsync.go
+++ b/pkg/connector/chatsync.go
@@ -118,8 +118,14 @@ func (tc *TwitterClient) syncXChatChannel(ctx context.Context, item *response.XC
 				tc.connector.br.WakeupBackfillQueue()
 			}
 		}
-	} else {
-		if shouldEmitChatInfoUpdate(chatInfo, portal.RoomType) {
+	} else if shouldEmitChatInfoUpdate(chatInfo, portal.RoomType) {
+		if evt := bridgev2.GetRemoteEventFromContext(ctx); evt != nil && evt.GetPortalKey().ID == portal.PortalKey.ID {
+			// Already inside this portal's own event handler (e.g. RefreshConversationKeys
+			// during message conversion). Queueing another event for the same portal would
+			// self-deadlock when the portal event queue is synchronous (PortalEventBuffer=0),
+			// so apply the update directly instead.
+			portal.UpdateInfo(ctx, chatInfo, tc.userLogin, nil, time.Time{})
+		} else {
 			tc.userLogin.QueueRemoteEvent(&simplevent.ChatInfoChange{
 				EventMeta: simplevent.EventMeta{
 					Type:      bridgev2.RemoteEventChatInfoChange,


### PR DESCRIPTION
## Problem
With a synchronous portal event queue (`PortalEventBuffer = 0`, as set by the Beeper client SDK), `syncXChatChannel` can be reached from inside a portal's own event handler (message conversion → `RefreshConversationKeys` → `HandleConversationDataRefresh`). Queueing a `ChatInfoChange` for the same portal from there blocks forever on `portal.eventsLock`, which the handler's own dispatcher holds. `Bridge.Start` then never returns, hanging bridge stop/start and leaving client sends stuck.

## Fix
When `bridgev2.GetRemoteEventFromContext(ctx)` shows we are already inside this portal's event handler, apply the chat info via `portal.UpdateInfo` directly (same as bridgev2's `handleRemoteChatResync`) instead of re-entering the event queue.

Linear: https://linear.app/beeper/issue/BIOS-35204/sanakh-ios-room-send-queue-waited-on-sdk-restart-leaving-whatsapp