### PR TITLE
twittermeow/login: re-prompt when X rejects a verification code

### DIFF
--- a/pkg/twittermeow/login_jetfuel.go
+++ b/pkg/twittermeow/login_jetfuel.go
@@ -462,6 +462,10 @@ func (wls *WebLoginSession) submitJetfuelText(ctx context.Context, text string) 
 			Challenge:        parsed.verificationChallenge(),
 		}, nil
 	}
+	if parsed.isActionlessRejection() {
+		wls.logUnsupportedJetfuelResponse(ctx, "text_code_rejected", wls.jetfuel.verificationAction, parsed)
+		return nil, &WebLoginError{Message: "Incorrect code. Enter the latest code X sent you."}
+	}
 	return wls.handleUnsupportedJetfuelResponse(ctx, "text", wls.jetfuel.verificationAction, parsed)
 }
 
@@ -897,6 +901,11 @@ func (jfr jetfuelLoginResponse) hasField(field string) bool {
 // Require parsed structure so an empty or opaque transport response does not trigger another password POST.
 func (jfr jetfuelLoginResponse) canReplayPasswordWithoutAction() bool {
 	return len(jfr.raw) > 0 && len(jfr.paths) > 0 && len(jfr.fields) > 0
+}
+
+// X answers a rejected verification code with a small structured body that carries no next action.
+func (jfr jetfuelLoginResponse) isActionlessRejection() bool {
+	return len(jfr.raw) > 0 && len(jfr.paths) == 0 && len(jfr.fields) > 0
 }
 
 func (jfr jetfuelLoginResponse) passwordAction() string {

--- a/pkg/twittermeow/login_web_test.go
+++ b/pkg/twittermeow/login_web_test.go
@@ -619,8 +619,7 @@ func TestUnsupportedJetfuelResponseLoggingOmitsResponseValues(t *testing.T) {
 }
 
 func TestUnparsedJetfuelResponsesReturnUnsupported(t *testing.T) {
-	const verificationAction = "/onboarding/web/actions/finish_login_email_verification"
-	for _, stage := range []string{"combined_credentials", "begin_two_factor", "text"} {
+	for _, stage := range []string{"combined_credentials", "begin_two_factor"} {
 		t.Run(stage, func(t *testing.T) {
 			client := NewClient(cookies.NewCookies(nil), nil, zerolog.Nop())
 			client.SetNextJetfuelCastleTokens([]string{"first-token", "second-token"})
@@ -644,9 +643,6 @@ func TestUnparsedJetfuelResponsesReturnUnsupported(t *testing.T) {
 			case "begin_two_factor":
 				session.jetfuel.passwordAction = endpoints.JETFUEL_LOGIN_ENTER_PASSWORD_PATH
 				result, err = session.SubmitPassword(context.Background(), "password")
-			case "text":
-				session.jetfuel.verificationAction = verificationAction
-				result, err = session.SubmitText(context.Background(), "123456")
 			}
 			if err != nil {
 				t.Fatalf("submit error = %v", err)
@@ -658,6 +654,56 @@ func TestUnparsedJetfuelResponsesReturnUnsupported(t *testing.T) {
 				t.Fatal("unsupported response retained Jetfuel state")
 			}
 		})
+	}
+}
+
+func TestSubmitJetfuelTextTreatsActionlessResponseAsRejectedCode(t *testing.T) {
+	const verificationAction = "/onboarding/web/actions/finish_login_email_verification"
+	client := NewClient(cookies.NewCookies(nil), nil, zerolog.Nop())
+	client.SetNextJetfuelCastleTokens([]string{"first-token", "second-token"})
+	client.HTTP = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return jetfuelTestResponse("unparsed"), nil
+	})}
+	session := NewWebLoginSession(client)
+	session.backend = webLoginBackendJetfuel
+	session.jetfuel = &jetfuelLoginState{verificationAction: verificationAction}
+
+	result, err := session.SubmitText(context.Background(), "123456")
+	if result != nil {
+		t.Fatalf("SubmitText() result = %#v, want nil", result)
+	}
+	var webErr *WebLoginError
+	if !errors.As(err, &webErr) {
+		t.Fatalf("SubmitText() error = %v, want *WebLoginError", err)
+	}
+	if !strings.Contains(strings.ToLower(webErr.Message), "incorrect code") {
+		t.Fatalf("SubmitText() error message = %q, want an incorrect code error", webErr.Message)
+	}
+	if session.jetfuel == nil || session.jetfuel.verificationAction != verificationAction {
+		t.Fatalf("rejected code discarded the Jetfuel session: %#v", session.jetfuel)
+	}
+}
+
+func TestSubmitJetfuelTextReturnsUnsupportedForUnknownAction(t *testing.T) {
+	const verificationAction = "/onboarding/web/actions/finish_login_email_verification"
+	client := NewClient(cookies.NewCookies(nil), nil, zerolog.Nop())
+	client.SetNextJetfuelCastleTokens([]string{"first-token", "second-token"})
+	client.HTTP = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return jetfuelTestResponse("/onboarding/web/actions/brand_new_step"), nil
+	})}
+	session := NewWebLoginSession(client)
+	session.backend = webLoginBackendJetfuel
+	session.jetfuel = &jetfuelLoginState{verificationAction: verificationAction}
+
+	result, err := session.SubmitText(context.Background(), "123456")
+	if err != nil {
+		t.Fatalf("SubmitText() error = %v", err)
+	}
+	if result == nil || result.Status != WebLoginStatusUnsupported {
+		t.Fatalf("SubmitText() result = %#v, want unsupported", result)
+	}
+	if session.jetfuel != nil {
+		t.Fatal("unsupported response retained Jetfuel state")
 	}
 }
 


### PR DESCRIPTION
When X rejects a verification code it replies 200 with a structured body that carries no next action, which fell through to the unsupported-response handler, dropping the Jetfuel session and dead-ending setup.

Treat an actionless text-stage response as a rejected code and return an error so the connector re-asks for the code with the session intact.
