### PR TITLE
Set length hints on the juicebox PIN login field

### DIFF
--- a/pkg/connector/login.go
+++ b/pkg/connector/login.go
@@ -266,6 +266,7 @@ var _ bridgev2.LoginProcessWithOverride = (*TwitterLogin)(nil)
 var _ bridgev2.LoginProcessWithParams = (*TwitterLogin)(nil)
 
 const (
+	pinLength           = 4
 	pinRegex            = "^[0-9]{4}$"
 	passcodeBodyRecover = "To retrieve your encrypted messages, please enter your passcode below. For more information see: https://help.x.com/en/using-x/about-chat"
 	passcodeBodySetup   = "No PIN code is registered yet. Create your X Chat PIN below."
@@ -656,10 +657,12 @@ func makePINStep(errorLine string, isSetup bool) *bridgev2.LoginStep {
 		UserInputParams: &bridgev2.LoginUserInputParams{
 			Fields: []bridgev2.LoginInputDataField{
 				{
-					Type:    bridgev2.LoginInputFieldType2FACode,
-					ID:      "pin",
-					Name:    fieldName,
-					Pattern: pinRegex,
+					Type:      bridgev2.LoginInputFieldType2FACode,
+					ID:        "pin",
+					Name:      fieldName,
+					Pattern:   pinRegex,
+					MinLength: pinLength,
+					MaxLength: pinLength,
 				},
 			},
 		},


### PR DESCRIPTION
Sets `MinLength`/`MaxLength` to 4 on the juicebox PIN field so clients can cap the input instead of silently disabling submit when a fifth digit is typed (beeper DESK-23336).

Depends on the mautrix-go change adding those fields to `LoginInputDataField`: https://github.com/SilverBirchh/go/tree/login-field-length. Needs a go.mod bump once that merges.