### PR TITLE
login: set length hints on the juicebox PIN login field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	golang.org/x/crypto v0.55.0
 	golang.org/x/sync v0.22.0
 	gopkg.in/yaml.v3 v3.0.1
-	maunium.net/go/mautrix v0.30.1-0.20260828211758-e9466a65f64c
+	maunium.net/go/mautrix v0.30.1-0.20260904095334-3ef5ae660622
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -182,5 +182,5 @@ gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=
 gotest.tools/v3 v3.5.2/go.mod h1:LtdLGcnqToBH83WByAAi/wiwSFCArdFIUV/xxN4pcjA=
 maunium.net/go/mauflag v1.0.0 h1:YiaRc0tEI3toYtJMRIfjP+jklH45uDHtT80nUamyD4M=
 maunium.net/go/mauflag v1.0.0/go.mod h1:nLivPOpTpHnpzEh8jEdSL9UqO9+/KBJFmNRlwKfkPeA=
-maunium.net/go/mautrix v0.30.1-0.20260828211758-e9466a65f64c h1:AakW6nCwwg1c3/XKK+M+ikCkt6IGTrzlgrZrVHNBHUA=
-maunium.net/go/mautrix v0.30.1-0.20260828211758-e9466a65f64c/go.mod h1:Y02sBiAvfEVqK24bwVGCprmLATRZ7prWel3ZpB413e0=
+maunium.net/go/mautrix v0.30.1-0.20260904095334-3ef5ae660622 h1:ORGMgCjYoof0UBLIvSZeoTaFBx5OAuLyruvljurDdAg=
+maunium.net/go/mautrix v0.30.1-0.20260904095334-3ef5ae660622/go.mod h1:Y02sBiAvfEVqK24bwVGCprmLATRZ7prWel3ZpB413e0=

--- a/pkg/connector/login.go
+++ b/pkg/connector/login.go
@@ -266,6 +266,7 @@ var _ bridgev2.LoginProcessWithOverride = (*TwitterLogin)(nil)
 var _ bridgev2.LoginProcessWithParams = (*TwitterLogin)(nil)
 
 const (
+	pinLength           = 4
 	pinRegex            = "^[0-9]{4}$"
 	passcodeBodyRecover = "To retrieve your encrypted messages, please enter your passcode below. For more information see: https://help.x.com/en/using-x/about-chat"
 	passcodeBodySetup   = "No PIN code is registered yet. Create your X Chat PIN below."
@@ -656,10 +657,12 @@ func makePINStep(errorLine string, isSetup bool) *bridgev2.LoginStep {
 		UserInputParams: &bridgev2.LoginUserInputParams{
 			Fields: []bridgev2.LoginInputDataField{
 				{
-					Type:    bridgev2.LoginInputFieldType2FACode,
-					ID:      "pin",
-					Name:    fieldName,
-					Pattern: pinRegex,
+					Type:      bridgev2.LoginInputFieldType2FACode,
+					ID:        "pin",
+					Name:      fieldName,
+					Pattern:   pinRegex,
+					MinLength: pinLength,
+					MaxLength: pinLength,
 				},
 			},
 		},


### PR DESCRIPTION
Sets MinLength/MaxLength to 4 on the juicebox PIN field. Bumps mautrix-go to pick up the new fields from mautrix/go#564.

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
